### PR TITLE
Fixed issues with player getting stuck at start of farm

### DIFF
--- a/src/main/java/FarmHelper/FarmHelper.java
+++ b/src/main/java/FarmHelper/FarmHelper.java
@@ -286,45 +286,38 @@ public class FarmHelper
                 setAntiStuck = true;
                 process4 = true;
                 stop();
-                new Thread(new Runnable() {
-                    @Override
-                    public void run() {
-                        try{
+                new Thread(() -> {
+                    try{
+                        process3 = false;
+                        Thread.sleep(100);
+                        KeyBinding.setKeyBindState(keybindS, true);
+                        Thread.sleep(300);
+                        KeyBinding.setKeyBindState(keybindS, false);
+                        KeyBinding.setKeyBindState(keybindA, true);
+                        Thread.sleep(300);
+                        KeyBinding.setKeyBindState(keybindA, false);
+                        KeyBinding.setKeyBindState(keybindD, true);
+                        Thread.sleep(300);
+                        KeyBinding.setKeyBindState(keybindD, false);
+                        Thread.sleep(300);
 
-                            process3 = false;
-
-
-                            Thread.sleep(100);
-                            KeyBinding.setKeyBindState(keybindS, true);
-                            Thread.sleep(300);
-                            KeyBinding.setKeyBindState(keybindS, false);
-                            KeyBinding.setKeyBindState(keybindA, true);
-                            Thread.sleep(300);
-                            KeyBinding.setKeyBindState(keybindA, false);
-                            KeyBinding.setKeyBindState(keybindD, true);
-                            Thread.sleep(300);
-                            KeyBinding.setKeyBindState(keybindD, false);
-                            Thread.sleep(300);
-
-                            if(Config.FarmType == FarmEnum.LAYERED){
-                                if(isWalkable(Utils.getFrontBlock())) {
-                                    initialX = (int)mc.thePlayer.posX;
-                                    initialZ = (int)mc.thePlayer.posZ;
-                                    process3 = true;
-                                }
-                                Utils.debugLog(mc.thePlayer, "Checking if stuck at start");
-                                if (!isWalkable(Utils.getFrontBlock()) && !isWalkable(Utils.getBackBlock()) && !isWalkable(Utils.getRightBlock()) && isWalkable(Utils.getLeftBlock())) {
-                                    Utils.debugLog(mc.thePlayer, "Stuck at start of farm, changing direction");
-                                    ExecuteRunnable(changeMotion);
-                                    Utils.debugLog(mc.thePlayer, "Changed direction");
-                                }
+                        if(Config.FarmType == FarmEnum.LAYERED){
+                            if(isWalkable(Utils.getFrontBlock())) {
+                                initialX = (int)mc.thePlayer.posX;
+                                initialZ = (int)mc.thePlayer.posZ;
+                                process3 = true;
                             }
-                            ExecuteRunnable(stopAntistuck);
-
-                            //exec
-                        }catch(Exception e){
-                            e.printStackTrace();
+                            Utils.debugLog(mc.thePlayer, "Checking if stuck at start");
+                            if (!isWalkable(Utils.getFrontBlock()) && !isWalkable(Utils.getBackBlock()) && !isWalkable(Utils.getRightBlock()) && isWalkable(Utils.getLeftBlock())) {
+                                Utils.debugLog(mc.thePlayer, "Stuck at start of farm, changing direction");
+                                ExecuteRunnable(changeMotion);
+                                Utils.debugLog(mc.thePlayer, "Changed direction");
+                            }
                         }
+                        ExecuteRunnable(stopAntistuck);
+                        //exec
+                    }catch(Exception e){
+                        e.printStackTrace();
                     }
                 }).start();
 
@@ -523,46 +516,40 @@ public class FarmHelper
     };
 
 
-    Runnable changeLayer = new Runnable() {
-        @Override
-        public void run() {
-            if(!notInIsland && !emergency) {
-                try {
-                    stop();
-                    rotating = true;
-                    enabled = false;
-                    Thread.sleep(1000);
-                    Config.Angle = Config.Angle.ordinal() < 2 ? AngleEnum.values()[Config.Angle.ordinal() + 2] : AngleEnum.values()[Config.Angle.ordinal() - 2];
-                    playerYaw = angleToValue(Config.Angle);
-                    Utils.smoothRotateClockwise(180);
-                    Thread.sleep(2000);
-                    rotating = false;
+    Runnable changeLayer = () -> {
+        if(!notInIsland && !emergency) {
+            try {
+                stop();
+                rotating = true;
+                enabled = false;
+                Thread.sleep(1000);
+                Config.Angle = Config.Angle.ordinal() < 2 ? AngleEnum.values()[Config.Angle.ordinal() + 2] : AngleEnum.values()[Config.Angle.ordinal() - 2];
+                playerYaw = angleToValue(Config.Angle);
+                Utils.smoothRotateClockwise(180);
+                Thread.sleep(2000);
+                rotating = false;
 
-                    // After 180 you are at back of trench, hold W for some time to go to front
-                    KeyBinding.setKeyBindState(keybindW, true);
-                    Thread.sleep(500);
-                    KeyBinding.setKeyBindState(keybindW, false);
+                // After 180 you are at back of trench, hold W for some time to go to front
+                KeyBinding.setKeyBindState(keybindW, true);
+                Thread.sleep(500);
+                KeyBinding.setKeyBindState(keybindW, false);
 
-                    enabled = true;
-                }catch(Exception e){
-                    e.printStackTrace();
-                }
-
+                enabled = true;
+            }catch(Exception e){
+                e.printStackTrace();
             }
+
         }
     };
 
-    Runnable changeMotion = new Runnable() {
-        @Override
-        public void run() {
-            Utils.debugLog(mc.thePlayer, "Trying to change motion");
-            if(!notInIsland && !emergency) {
-                process1 = !process1;
-                process2 = !process2;
-                Utils.debugLog(mc.thePlayer, "1:" + process1 + ", 2: " + process2 + ", 3: " + process3 + ", 4: " + process4);
-                Utils.debugLog(mc.thePlayer, "Motion function: changed");
-                set = false;
-            }
+    Runnable changeMotion = () -> {
+        Utils.debugLog(mc.thePlayer, "Trying to change motion");
+        if(!notInIsland && !emergency) {
+            process1 = !process1;
+            process2 = !process2;
+            Utils.debugLog(mc.thePlayer, "1:" + process1 + ", 2: " + process2 + ", 3: " + process3 + ", 4: " + process4);
+            Utils.debugLog(mc.thePlayer, "Motion function: changed");
+            set = false;
         }
     };
 

--- a/src/main/java/FarmHelper/FarmHelper.java
+++ b/src/main/java/FarmHelper/FarmHelper.java
@@ -42,7 +42,6 @@ import java.lang.reflect.Field;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
-
 @Mod(modid = FarmHelper.MODID, name = FarmHelper.NAME, version = FarmHelper.VERSION)
 public class FarmHelper
 {
@@ -209,7 +208,7 @@ public class FarmHelper
                 Utils.drawString("profit/h = " + moneyper10sec * 6 * 60, 6, 104, 0.8f, -1);
             }
 
-            mc.fontRendererObj.drawString(  Utils.getFrontBlock()+ " " + Utils.getBackBlock().toString(), 4, new ScaledResolution(mc).getScaledHeight() - 20, -1);
+            mc.fontRendererObj.drawString(Utils.getFrontBlock() + " " + Utils.getBackBlock().toString() + " " + Utils.getRightBlock().toString() + " " + Utils.getLeftBlock().toString(), 4, new ScaledResolution(mc).getScaledHeight() - 20, -1);
 
 
         }
@@ -305,11 +304,19 @@ public class FarmHelper
                             KeyBinding.setKeyBindState(keybindD, true);
                             Thread.sleep(300);
                             KeyBinding.setKeyBindState(keybindD, false);
+                            Thread.sleep(300);
+
                             if(Config.FarmType == FarmEnum.LAYERED){
                                 if(isWalkable(Utils.getFrontBlock())) {
                                     initialX = (int)mc.thePlayer.posX;
                                     initialZ = (int)mc.thePlayer.posZ;
                                     process3 = true;
+                                }
+                                Utils.debugLog(mc.thePlayer, "Checking if stuck at start");
+                                if (!isWalkable(Utils.getFrontBlock()) && !isWalkable(Utils.getBackBlock()) && !isWalkable(Utils.getRightBlock()) && isWalkable(Utils.getLeftBlock())) {
+                                    Utils.debugLog(mc.thePlayer, "Stuck at start of farm, changing direction");
+                                    ExecuteRunnable(changeMotion);
+                                    Utils.debugLog(mc.thePlayer, "Changed direction");
                                 }
                             }
                             ExecuteRunnable(stopAntistuck);
@@ -532,6 +539,12 @@ public class FarmHelper
                     Utils.smoothRotateClockwise(180);
                     Thread.sleep(2000);
                     rotating = false;
+
+                    // After 180 you are at back of trench, hold W for some time to go to front
+                    KeyBinding.setKeyBindState(keybindW, true);
+                    Thread.sleep(500);
+                    KeyBinding.setKeyBindState(keybindW, false);
+
                     enabled = true;
                 }catch(Exception e){
                     e.printStackTrace();
@@ -543,9 +556,12 @@ public class FarmHelper
     Runnable changeMotion = new Runnable() {
         @Override
         public void run() {
+            Utils.debugLog(mc.thePlayer, "Trying to change motion");
             if(!notInIsland && !emergency) {
                 process1 = !process1;
                 process2 = !process2;
+                Utils.debugLog(mc.thePlayer, "1:" + process1 + ", 2: " + process2 + ", 3: " + process3 + ", 4: " + process4);
+                Utils.debugLog(mc.thePlayer, "Motion function: changed");
                 set = false;
             }
         }
@@ -765,13 +781,17 @@ public class FarmHelper
         }
     }
     void initialize(){
+         Utils.debugLog(mc.thePlayer, "Initializing");
         deltaX = 10000;
         deltaZ = 10000;
         deltaY = 0;
 
-
         process1 = true;
         process2 = false;
+        if (!isWalkable(Utils.getFrontBlock()) && !isWalkable(Utils.getBackBlock()) && !isWalkable(Utils.getRightBlock()) && isWalkable(Utils.getLeftBlock())) {
+            process1 = false;
+            process2 = true;
+        }
         process3 = false;
         process4 = false;
         if(Config.FarmType == FarmEnum.LAYERED){
@@ -779,7 +799,6 @@ public class FarmHelper
                 process3 = true;
             }
         }
-
 
         setspawned = false;
         shdBePressingKey = true;

--- a/src/main/java/FarmHelper/utils/Utils.java
+++ b/src/main/java/FarmHelper/utils/Utils.java
@@ -3,10 +3,13 @@ package FarmHelper.utils;
 import FarmHelper.config.Config;
 import net.minecraft.block.Block;
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.entity.EntityPlayerSP;
 import net.minecraft.client.gui.Gui;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.inventory.Slot;
 import net.minecraft.util.BlockPos;
+import net.minecraft.util.ChatComponentText;
+import net.minecraft.util.EnumChatFormatting;
 
 import java.util.Random;
 
@@ -203,6 +206,22 @@ public class Utils {
                 new BlockPos(mc.thePlayer.getLookVec().xCoord * -1 + mc.thePlayer.posX, mc.thePlayer.posY,
                         mc.thePlayer.getLookVec().zCoord * -1 + mc.thePlayer.posZ)).getBlock());
     }
-
-
+    public static Block getRightBlock(){
+        Minecraft mc = Minecraft.getMinecraft();
+        return (mc.theWorld.getBlockState(
+          new BlockPos(mc.thePlayer.getLookVec().zCoord * -1 + mc.thePlayer.posX, mc.thePlayer.posY,
+            mc.thePlayer.getLookVec().xCoord + mc.thePlayer.posZ)).getBlock());
+    }
+    public static Block getLeftBlock(){
+        Minecraft mc = Minecraft.getMinecraft();
+        return (mc.theWorld.getBlockState(
+          new BlockPos(mc.thePlayer.getLookVec().zCoord + mc.thePlayer.posX, mc.thePlayer.posY,
+            mc.thePlayer.getLookVec().xCoord * -1 + mc.thePlayer.posZ)).getBlock());
+    }
+    public static void debugLog(EntityPlayerSP player, String message) {
+        if (false) {
+            player.addChatMessage(new ChatComponentText(EnumChatFormatting.GREEN +
+              "[Debug]: " + EnumChatFormatting.DARK_GREEN + message));
+        }
+    }
 }


### PR DESCRIPTION
Player would get stuck at start of farm, getting into anti-stuck loop. This would also occur on layer change as it would re initialize.

**Solution:** Check blocks around the player, if it could only go to the left, then run `changeMotion`.

**Changes I made:**
For fixing the problem: I added the condition into anti-stuck so when it gets into an anti-stuck loop it will check for that condition and fix itself.
However this does take 3-4s, and so I also added this check inside `initialize` when it sets values for `process1` and `process2`. So it will instantly go the right way when starting at the start, or layer changing. However the check in anti-stuck is still needed if you start from the middle of the row and it goes the wrong way to the start of the farm, there it needs anti-stuck to help it go the right way. Maybe the check/condition can be added to a separate function later for modularity

I also added `debugLog` so I could log variables easier for myself. I hardcode the value of the if statement in the `debugLog` function to `true` when in development and `false` when I commit so none of the users see it but the log statements will still be there in the code. Maybe later there can be a config option that can turn on/off debug logs so we dont have to change this in the code